### PR TITLE
Topic/impl update method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
     - U
       ```jsonc
       {
+        "_id": "xxxxxxxxxxxx", // 更新対象のドキュメントのID
         "action": "update", // 操作の種類
         "document": "users", // ドキュメント名
         "data": { // 更新するデータ

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
     - R
       ```jsonc
       {
+        "_id": "xxxxxxxxxxxx", // 取得対象のドキュメントのID
         "action": "read", // 操作の種類
         "document": "users" // ドキュメント名
       }
@@ -53,6 +54,7 @@
     - D
       ```jsonc
       {
+        "_id": "xxxxxxxxxxxx", // 削除対象のドキュメントのID
         "action": "delete", // 操作の種類
         "document": "users" // ドキュメント名
       }

--- a/connect_handler.go
+++ b/connect_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 
 	"github.com/olahol/melody"
@@ -29,7 +30,12 @@ func ConnectHandler(client *mongo.Client) func(s *melody.Session) {
 				log.Fatal(err)
 			}
 
-			s.Write([]byte(result.Data["message"].(string)))
+			bytes, err := json.Marshal(result)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			s.Write(bytes)
 		}
 	}
 }

--- a/message_handler.go
+++ b/message_handler.go
@@ -30,6 +30,11 @@ func MessageHandler(client *mongo.Client, m *melody.Melody) func(s *melody.Sessi
 		switch jsondata.Action {
 		case "create":
 			// データをDBに登録
+			insertResult, err := collection.InsertOne(context.Background(), jsondata)
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Default().Println("Insert a single document: ", insertResult.InsertedID)
 		case "read":
 			// データをDBから取得
 		case "update":
@@ -39,12 +44,6 @@ func MessageHandler(client *mongo.Client, m *melody.Melody) func(s *melody.Sessi
 		default:
 			// 何もしない
 		}
-		insertResult, err := collection.InsertOne(context.Background(), jsondata)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		log.Default().Println("Insert a single document: ", insertResult.InsertedID)
 
 		// DBに登録されたデータをブロードキャスト
 		m.Broadcast([]byte(jsondata.Data["message"].(string)))

--- a/message_handler.go
+++ b/message_handler.go
@@ -21,12 +21,24 @@ type Message struct {
 
 func MessageHandler(client *mongo.Client, m *melody.Melody) func(s *melody.Session, msg []byte) {
 	return func(s *melody.Session, msg []byte) {
-		// DBにデータを登録する
 		collection := client.Database("chat").Collection("message")
 		// jsonデータのメッセージをbsonデータに変換する
 		// https://www.mongodb.com/docs/drivers/go/current/fundamentals/bson/
 		var jsondata Message
 		json.Unmarshal(msg, &jsondata)
+		// jsondataのActionによって処理を分岐
+		switch jsondata.Action {
+		case "create":
+			// データをDBに登録
+		case "read":
+			// データをDBから取得
+		case "update":
+			// データをDBで更新
+		case "delete":
+			// データをDBから削除
+		default:
+			// 何もしない
+		}
 		insertResult, err := collection.InsertOne(context.Background(), jsondata)
 		if err != nil {
 			log.Fatal(err)

--- a/message_handler.go
+++ b/message_handler.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 
 	"github.com/olahol/melody"
@@ -42,7 +41,6 @@ func MessageHandler(client *mongo.Client, m *melody.Melody) func(s *melody.Sessi
 		case "read":
 			// データをDBから取得
 		case "update":
-			fmt.Println(jsondata)
 			// DB上のデータを更新
 			// 送信されたメッセージのIDを取得し、DB上のデータを更新する
 			filter := bson.D{{Key: "id", Value: jsondata.Data["id"]}}
@@ -57,7 +55,12 @@ func MessageHandler(client *mongo.Client, m *melody.Melody) func(s *melody.Sessi
 			// 何もしない
 		}
 
+		bytes, err := json.Marshal(jsondata)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		// DBに登録されたデータをブロードキャスト
-		m.Broadcast([]byte(jsondata.Data["message"].(string)))
+		m.Broadcast(bytes)
 	}
 }

--- a/message_handler.go
+++ b/message_handler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/olahol/melody"
@@ -41,6 +42,7 @@ func MessageHandler(client *mongo.Client, m *melody.Melody) func(s *melody.Sessi
 		case "read":
 			// データをDBから取得
 		case "update":
+			fmt.Println(jsondata)
 			// DB上のデータを更新
 			// 送信されたメッセージのIDを取得し、DB上のデータを更新する
 			filter := bson.D{{Key: "id", Value: jsondata.Data["id"]}}


### PR DESCRIPTION
# 実装内容
- WebSocketのメッセージの `action` に応じて条件分岐
- `action == "update"` の場合の処理の実装
- `action == "create"` の場合の処理を `case` 内に移動
- データ更新に伴い、WebSocketのメッセージのデータ構造を変更する
  - `data` にプロパティ `id` を追加
- バックエンドから返すデータ構造を定義
  - 現在は文字列だが、データ構造をしっかり定義してやりとり